### PR TITLE
Add links to specifications

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,10 @@
 # WebApiDevice
+
+## Draft Specifications
+
+* [Managed Configuration API](https://wicg.github.io/WebApiDevice/managed_config)
+* [Device Attributes API](https://wicg.github.io/WebApiDevice/device_attributes/)
+
 ## How to test these features?
 
 ### Preconditions


### PR DESCRIPTION
You're going to have to change the Github Pages source to the `gh-pages` branch in order for the Device Attributes link to work. See https://docs.github.com/en/pages/getting-started-with-github-pages/configuring-a-publishing-source-for-your-github-pages-site.