### PR TITLE
Define `NavigatorManagedMedia` as a `partial interface`

### DIFF
--- a/device_attributes/index.bs
+++ b/device_attributes/index.bs
@@ -16,6 +16,7 @@ spec:url; type:dfn; text:origin
 spec:html; type:dfn; for:/; text:global object
 spec:webidl; type:dfn; text:resolve
 spec:webidl; type:dfn; text:record
+spec:managed-configuration; type:interface; text:NavigatorManagedData
 </pre>
  
 <pre class="anchors">
@@ -69,10 +70,7 @@ A manufacturer-defined value which uniquely identifies a device among those prod
 # {{NavigatorManagedData}} interface # {#navigatormanageddata-interface}
  
 <xmp class="idl">
-[
-  SecureContext,
-  Exposed=Window
-] interface NavigatorManagedData : EventTarget {
+partial interface NavigatorManagedData {
   // Device Attributes API.
   Promise<DOMString> getAnnotatedAssetId();
   Promise<DOMString> getAnnotatedLocation();


### PR DESCRIPTION
The `NavigatorManagedMedia` is defined in Managed Configuration API. The Device Attributes API can only extend it through a `partial interface` definition.

Note the addition of an entry to "link-defaults" is needed on a temporary basis: due to the duplicate, the cross-references database currently has two definitions of `NavigatorManagedMedia`, and Bikeshed would choose the wrong one, creating a broken link. The entry can be removed once the spec has been re-generated and the change propagated to the cross-references database (which should take maximum 6 hours).